### PR TITLE
Fixed Telegram chat link

### DIFF
--- a/_posts/2017-11-18-welcome.md
+++ b/_posts/2017-11-18-welcome.md
@@ -18,6 +18,6 @@ Cos'è il *Wall-of-fame*?
 
 Detto questo, buona navigazione e **stay tuned**! 😎
 
-* [GDG Pisa on Telegram](https://t.me/joinchat/B1xkFD9ooAqvs5r2xLO9KQ)
+* [GDG Pisa on Telegram](https://t.me/joinchat/B1xkFD9ooAoxNZLgoJU9-A)
 * [GDG Pisa on Twitter](http://twitter.com/gdgPisa)
 * [GDG Pisa on Facebook](http://facebook.com/gdgPisa)

--- a/_posts/2017-11-19-lets-organize-devfest.md
+++ b/_posts/2017-11-19-lets-organize-devfest.md
@@ -26,6 +26,6 @@ Nel caso te lo stessi chiedendo la risposta è semplice: **tu sei già parte del
 
 ### 📇 Contatti
 Se hai delle domande da farci o semplicemente vuoi tenerti in contatto con noi eccoti i nostri contatti:
-* [GDG Pisa on Telegram](https://t.me/joinchat/B1xkFD9ooAqvs5r2xLO9KQ)
+* [GDG Pisa on Telegram](https://t.me/joinchat/B1xkFD9ooAoxNZLgoJU9-A)
 * [GDG Pisa on Twitter](http://twitter.com/gdgPisa)
 * [GDG Pisa on Facebook](http://facebook.com/gdgPisa)

--- a/_posts/2017-11-30-media-partnership-con-linuxlab.md
+++ b/_posts/2017-11-30-media-partnership-con-linuxlab.md
@@ -19,6 +19,6 @@ I ticket disponibili online:
 
 Vi aspettiamo al Linux Lab!
 
-* [GDG Pisa on Telegram](https://t.me/joinchat/B1xkFD9ooAqvs5r2xLO9KQ)
+* [GDG Pisa on Telegram](https://t.me/joinchat/B1xkFD9ooAoxNZLgoJU9-A)
 * [GDG Pisa on Twitter](http://twitter.com/gdgPisa)
 * [GDG Pisa on Facebook](http://facebook.com/gdgPisa)

--- a/_posts/2017-12-08-javascript-from-zero-to-jedi.md
+++ b/_posts/2017-12-08-javascript-from-zero-to-jedi.md
@@ -41,6 +41,6 @@ Sei pronto a scoprire come **Javascript** può guidarti contro il lato oscuro? L
 
 [Vi aspettiamo!](https://www.meetup.com/GDG-Pisa/events/245661502/).
 
-* [GDG Pisa on Telegram](https://t.me/joinchat/B1xkFD9ooAqvs5r2xLO9KQ)
+* [GDG Pisa on Telegram](https://t.me/joinchat/B1xkFD9ooAoxNZLgoJU9-A)
 * [GDG Pisa on Twitter](http://twitter.com/gdgPisa)
 * [GDG Pisa on Facebook](http://facebook.com/gdgPisa)

--- a/_posts/2018-4-10-ripartiamo-alla-grande-con-io-extended.md
+++ b/_posts/2018-4-10-ripartiamo-alla-grande-con-io-extended.md
@@ -36,6 +36,6 @@ Ti aspettiamo all'I/O Extended, non mancare!
 
 _Lo staff del GDG Pisa_
 
-* [GDG Pisa on Telegram](https://t.me/joinchat/B1xkFD9ooAqvs5r2xLO9KQ)
+* [GDG Pisa on Telegram](https://t.me/joinchat/B1xkFD9ooAoxNZLgoJU9-A)
 * [GDG Pisa on Twitter](http://twitter.com/gdgPisa)
 * [GDG Pisa on Facebook](http://facebook.com/gdgPisa)


### PR DESCRIPTION
Looks like we still had some old telegram links around

### Checklist:

* [x] Have you tested the website locally?
* [x] Have you checked the logs?
* [ ] Have you commented your code? N/A